### PR TITLE
Image-Source Replacement für Snippets auf SSL-Seiten

### DIFF
--- a/OXID/modules/toxid_curl/core/toxidcurl.php
+++ b/OXID/modules/toxid_curl/core/toxidcurl.php
@@ -158,6 +158,23 @@ class toxidCurl extends oxSuperCfg
 
         $this->_aCustomPage = null;
 
+        /* if actual site is ssl-site, replace all image-sources with ssl-urls */
+        if ($this->getConfig()->isSsl()) {
+
+            $sslRepArray = $this->getConfig()->getConfigParam('aToxidCurlSslPicReplacement');
+            $sslRepUrls = $sslRepArray[$sLangId];
+
+            if (is_array($sslRepUrls)) {
+
+                $oldSrc = $sslRepUrls[0];
+                $newSrc = $sslRepUrls[1];
+
+                if ($oldSrc != "" && $newSrc != "") {
+                    $sText= str_replace('src="'.$oldSrc, 'src="'.$newSrc, $sText);
+                }
+            }
+        }
+
         if($this->getConfig()->getConfigParam('iUtfMode') !== 1)
         {
 			$sText= str_replace("�", "\"", $sText);
@@ -182,7 +199,7 @@ class toxidCurl extends oxSuperCfg
         if ($this->_sPageContent !== null && !$blReset) {
             return $this->_sPageContent;
         }
-        
+
         $source = $this->_getToxidLangSource();
         $page = $this->getConfig()->getConfigParam('sToxidCurlPage');
         $param = $this->_getToxidLangUrlParam();
@@ -202,11 +219,11 @@ class toxidCurl extends oxSuperCfg
                 oxUtils::getInstance()->showMessageAndExit('');
                 break;
         }
-		
+
 		// Especially for Wordpress-Frickel-Heinze
 		// Kill everything befor the <?xml
 		$this->_sPageContent = preg_replace('/.*<\?xml/ms', '<?xml', $aPage['content']);
-				
+
 		return $this->_sPageContent;
 
     }
@@ -253,7 +270,7 @@ class toxidCurl extends oxSuperCfg
      */
     protected function _rewriteUrls($sContent, $iLangId = null, $blMultiLang = false)
     {
-        
+
         if ($blMultiLang == false) {
             if ($iLangId === null) {
                 $iLangId = oxLang::getInstance()->getBaseLanguage();
@@ -276,7 +293,7 @@ class toxidCurl extends oxSuperCfg
 			}
 			unset($match);
         }
-        
+
         return $sContent;
     }
 
@@ -330,7 +347,7 @@ class toxidCurl extends oxSuperCfg
         if ($iLangId === null) {
             $iLangId = oxLang::getInstance()->getBaseLanguage();
         }
-        
+
         return $this->_aRewriteStartUrl[$iLangId];
     }
 

--- a/README
+++ b/README
@@ -19,7 +19,7 @@ What it is NOT
 #########################
 1) NO Single-Sign-On (so no restriced pages are possible)
    See TOXID with OxAPI
-   
+
 2) NO out-of-the-box solution
 
 
@@ -32,9 +32,9 @@ Installation / Config
 2) Add autloader to modules/functions.php
 
 	require_once('toxid_curl/toxid_curl_autoloader.php');
-	
-	
-#####	
+
+
+#####
 3) OXID eShop from Version 4.6
 	Activate module in admin
 
@@ -44,8 +44,8 @@ Installation / Config
 	oxseodecoder => toxid_curl/core/toxid_curl_oxseodecoder
 	oxviewconfig => toxid_curl/core/toxid_curl_oxviewconfig
 
-	
-#####	
+
+#####
 4) Set up your CMS to deliver the pages in UTF-8 XML-format
 
 	<?xml version="1.0"?>
@@ -53,7 +53,7 @@ Installation / Config
 		<part1></part1>
 		<part2></part2>
 	</toxid>
-	
+
 It is STRONGLY recommended to wrap your snippets/parts in CDATA to prevent XML-mistaktes
 
 
@@ -65,7 +65,7 @@ It is STRONGLY recommended to wrap your snippets/parts in CDATA to prevent XML-m
 									'0' => 'toxid-curl',
 									'1' => 'toxid-curl-en',
 								  );
-	
+
 	// URL to your CMS
 	$this->aToxidCurlSource	= array(
 								'0' => 'http://yourcmspage.com/',
@@ -77,18 +77,24 @@ It is STRONGLY recommended to wrap your snippets/parts in CDATA to prevent XML-m
 								'1' => '?type=1',
 							  );
 
+    // If actual Site is an SSL-site, replace first URL with second URL (only replaces image-source-attributes)
+    $this->aToxidCurlSslPicReplacement = array(
+        '0' => array('http://yourcmspage.com/', 'https://yourcmspage.com'),
+        '1' => array('http://yourcmspage.com/en/', 'https://yourcmspage.com/en/'),
+    );
+
 	// FOR BACKWARDS COMPATABILITY UNCOMENT
 	// template variable name, with will be accessible like [{$toxid_curl_cmp->getCmsSnippet('text1')}]
 	// $this->sTplVariable = 'toxid_curl_cmp';
-	
 
-		
-#####	
+
+
+#####
 6) now you can call your snippets via the component like this
 
-   [{assign var='toxid' value=$oViewConf->getToxid()}] 
+   [{assign var='toxid' value=$oViewConf->getToxid()}]
    [{ $toxid->getCmsSnippet(part1) }]
-   
+
 #####
 7) to use search functionality, config.inc.php mus contain search urls:
 


### PR DESCRIPTION
Habe eine kleine Erweiterung geschrieben, die alle "src"-Attribute von SEO-Snippets ersetzt, wenn man auf eine https-Seite gelangt.

Hatten einen Shop mit einem Toxid-Snippet im Footer, welches ein Bild ausgibt. 
Auf SSL-Seiten war das Zertifikat unsicher, da Toxid  die Sources nicht umgewandelt hat.

Config im Live-Betrieb:
http://awesomescreenshot.com/023jkhsb9

Vor dem Login:
http://awesomescreenshot.com/07bjki5a0

Nach dem Login:
http://awesomescreenshot.com/094jkix82
