### PR TITLE
Fatal error: Cannot redeclare class toxid_events on line 53

### DIFF
--- a/core/toxid_curl_events.php
+++ b/core/toxid_curl_events.php
@@ -14,7 +14,7 @@
  * @package   core
  */
 
-class toxid_events extends oxI18n {
+class toxid_curl_events.php extends oxI18n {
 
 	public static function onActivate() {
 


### PR DESCRIPTION
Classname must be same as Filename.
