### PR TITLE
Fixed buggy encoding detection. Locked to latin15/utf8.

### DIFF
--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -226,15 +226,9 @@ class toxidCurl extends oxSuperCfg
         }
 
         $sShopCharset = oxRegistry::getLang()->translateString('charset');
-        $strEnc = mb_detect_encoding($sText, "UTF-8,ISO-8859-1,$sShopCharset");
-        if($oConf->getConfigParam('iUtfMode') != 1)
+        if($oConf->getConfigParam('iUtfMode') === 0)
         {
-            $sText= str_replace("�", "\"", $sText);
-            $sText= str_replace("�", "\"", $sText);
-            $sText= str_replace("�", "'", $sText);
-            $sText= str_replace("�", "'", $sText);
-            $sText= str_replace("�", "-", $sText);
-            $sText = mb_convert_encoding($sText, $strEnc, 'UTF-8');
+            $sText = utf8_decode($sText);
             return $sText;
         } else {
             return $sText;


### PR DESCRIPTION
Erkennungslogik vereinfacht. Es wird nicht mehr mittels mb_detect_encoding die Kodierung automatisch erkannt (hat nicht funktioniert, und ist in manchen Fällen nicht wirklich zuverlässig), sondern es wird anhand der config.inc.php Einstellungen entweder latin15 oder utf8 verwendet.
