### PR TITLE
Added composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+  "name": "jkrug/toxid_curl",
+  "description": "",
+  "type": "oxid-module",
+  "license": "GPL-3.0",
+  "require": {
+    "composer/installers": "~1.0"
+  }
+}


### PR DESCRIPTION
You love composer.
I love composer.
We all love composer.

Toxid is now installable using:

```
{
    "repositories": [
      { "type": "vcs", "url":  "https://github.com/jkrug/TOXID-cURL.git" }
    ],

    "require": {
      "jkrug/toxid_curl": "dev-master"
    },

    "extra": {
      "installer-paths": {
        "shop/modules/toxid_curl": ["jkrug/toxid_curl"],
      }
}
```
