### PR TITLE
use Mall-Url in EE-version

### DIFF
--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -347,7 +347,15 @@ class toxidCurl extends oxSuperCfg
         }
 
         foreach ($aLanguages as $iLangId ) {
-            $target = $this->getConfig()->getConfigParam('sShopURL').$this->_getToxidLangSeoSnippet($iLangId).'/';
+            if ($this->getConfig()->getEdition() === 'EE') {
+                $sShopUrl = $this->getConfig()->getConfigParam('sMallShopURL');
+            } else {
+                $sShopUrl = $this->getConfig()->getConfigParam('sShopURL');
+            }
+            if (substr($sShopUrl, -1) !== '/') {
+                $sShopUrl = $sShopUrl.'/';
+            }
+            $target = $sShopUrl.$this->_getToxidLangSeoSnippet($iLangId).'/';
             $source = $this->_getToxidLangSource($iLangId);
             $pattern = '%href=(\'|")' . $source . '[^"\']*(.|/|\.html|\.php|\.asp)(\?[^"\']*)?(\'|")%';
             preg_match_all($pattern, $sContent, $matches, PREG_SET_ORDER);


### PR DESCRIPTION
We need the Mall-ShopUrls in the enterprise version of OXID
