### PR TITLE
only active lang load and snippet at the beginning matches

### DIFF
--- a/core/toxid_curl_oxseodecoder.php
+++ b/core/toxid_curl_oxseodecoder.php
@@ -6,51 +6,62 @@
  *    it under the terms of the MIT License.
  *
  *
- * @link      http://toxid.org
- * @link      http://marmalade.de
- * @package   core
+ * @link          http://toxid.org
+ * @link          http://marmalade.de
+ * @package       core
  * @copyright (C) marmalade.de 2011
  */
- 
 class toxid_curl_oxseodecoder extends toxid_curl_oxseodecoder_parent
 {
-    
-    public function decodeUrl( $sSeoUrl )
+
+    /**
+     * @param $sSeoUrl
+     *
+     * @return array
+     */
+    public function decodeUrl($sSeoUrl)
     {
         // check, if SeoUrl starts with t3contenturl
         $blIsToxidPage = $this->detectToxidAndLang($sSeoUrl);
-        if( !$blIsToxidPage )
-        {
+        if (!$blIsToxidPage) {
             return parent::decodeUrl($sSeoUrl);
-        }else{
+        } else {
             $aRet['cl'] = 'toxid_curl';
             $aRet['lang'] = $blIsToxidPage['lang'];
             oxRegistry::getLang()->setBaseLanguage($aRet['lang']);
-            $toxidUrl =  $blIsToxidPage['url'];
-            $this->getConfig()->setConfigParam('sToxidCurlPage',$toxidUrl);
+            $toxidUrl = $blIsToxidPage['url'];
+            $this->getConfig()->setConfigParam('sToxidCurlPage', $toxidUrl);
+
             return $aRet;
         }
     }
 
-
     /**
      * detect if page is toxidPage
      * if so, return array with langId and URL part
+     *
+     * @param string $sSeoUrl seo url to encode
+     *
+     * @return array|bool
      */
-    protected function detectToxidAndLang($sSeoUrl){
+    protected function detectToxidAndLang($sSeoUrl)
+    {
         $seoSnippets = $this->getConfig()->getConfigParam('aToxidCurlSeoSnippets');
-        foreach($seoSnippets as $langId => $snippet)
-        {
-            if(strpos( $sSeoUrl, $snippet.'/') !== FALSE)
-            {
-                $aUrlSplit = explode($snippet.'/', $sSeoUrl);
-                $toxidInfo = array(
-                                'lang' => $langId,
-                                'url' => $aUrlSplit[1],
-                             );
-                return $toxidInfo;
-            }
+        $langId = oxRegistry::getLang()->getBaseLanguage();
+        if (!isset($seoSnippets[$langId])) {
+            return false;
         }
+        $snippet = $seoSnippets[$langId];
+        if ($snippet !== '' && substr($sSeoUrl, 0, strlen($snippet . '/')) === $snippet . '/') {
+            $aUrlSplit = explode($snippet . '/', $sSeoUrl);
+            $toxidInfo = array(
+                'lang' => $langId,
+                'url'  => $aUrlSplit[1],
+            );
+
+            return $toxidInfo;
+        }
+
         // if nothing was found, return false
         return false;
     }


### PR DESCRIPTION
It loads the cms-url and snippet by active language. It matches only if the snippet is in the beginning.
If the first snippet is empty, the snippet matches every time and each page of oxid load the homepage of the cms.
e.g. snippet is "content"

product/abccontent/ <- matches