### PR TITLE
Wordpress Optimierungen

### DIFF
--- a/controller/admin/toxid_setup_main.php
+++ b/controller/admin/toxid_setup_main.php
@@ -17,6 +17,7 @@ class toxid_setup_main extends oxAdminView
         $this->_aViewData['aToxidCurlUrlParams']         = $oConf->getShopConfVar('aToxidCurlUrlParams');
         $this->_aViewData['aToxidCurlSeoSnippets']       = $oConf->getShopConfVar('aToxidCurlSeoSnippets');
         $this->_aViewData['toxidDontRewriteRelUrls']     = $oConf->getShopConfVar('toxidDontRewriteRelUrls');
+        $this->_aViewData['toxidRewriteUrlEncoded']      = $oConf->getShopConfVar('toxidRewriteUrlEncoded');
         $this->_aViewData['toxidDontRewriteUrls']        = $oConf->getShopConfVar('toxidDontRewriteUrls');
         $this->_aViewData['bToxidDontPassPostVarsToCms'] = $oConf->getShopConfVar('bToxidDontPassPostVarsToCms');
 
@@ -39,6 +40,7 @@ class toxid_setup_main extends oxAdminView
         $oConf->saveShopConfVar( 'arr', 'aToxidCurlUrlParams', $aParams['aToxidCurlUrlParams'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'arr', 'aToxidCurlSeoSnippets', $aParams['aToxidCurlSeoSnippets'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'str', 'toxidDontRewriteRelUrls', $aParams['toxidDontRewriteRelUrls'], $sShopId, self::CONFIG_MODULE_NAME );
+        $oConf->saveShopConfVar( 'bl', 'toxidRewriteUrlEncoded', $aParams['toxidRewriteUrlEncoded'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'bl', 'toxidDontRewriteUrls', $aParams['toxidDontRewriteUrls'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'bl', 'bToxidDontPassPostVarsToCms', $aParams['bToxidDontPassPostVarsToCms'], $sShopId, self::CONFIG_MODULE_NAME );
     }

--- a/controller/admin/toxid_setup_main.php
+++ b/controller/admin/toxid_setup_main.php
@@ -16,6 +16,7 @@ class toxid_setup_main extends oxAdminView
         $this->_aViewData['aToxidSearchUrl']             = $oConf->getShopConfVar('aToxidSearchUrl');
         $this->_aViewData['aToxidCurlUrlParams']         = $oConf->getShopConfVar('aToxidCurlUrlParams');
         $this->_aViewData['aToxidCurlSeoSnippets']       = $oConf->getShopConfVar('aToxidCurlSeoSnippets');
+        $this->_aViewData['toxidDontRewriteRelUrls']     = $oConf->getShopConfVar('toxidDontRewriteRelUrls');
         $this->_aViewData['toxidDontRewriteUrls']        = $oConf->getShopConfVar('toxidDontRewriteUrls');
         $this->_aViewData['bToxidDontPassPostVarsToCms'] = $oConf->getShopConfVar('bToxidDontPassPostVarsToCms');
 
@@ -37,6 +38,7 @@ class toxid_setup_main extends oxAdminView
         $oConf->saveShopConfVar( 'arr', 'aToxidSearchUrl', $aParams['aToxidSearchUrl'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'arr', 'aToxidCurlUrlParams', $aParams['aToxidCurlUrlParams'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'arr', 'aToxidCurlSeoSnippets', $aParams['aToxidCurlSeoSnippets'], $sShopId, self::CONFIG_MODULE_NAME );
+        $oConf->saveShopConfVar( 'str', 'toxidDontRewriteRelUrls', $aParams['toxidDontRewriteRelUrls'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'bl', 'toxidDontRewriteUrls', $aParams['toxidDontRewriteUrls'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'bl', 'bToxidDontPassPostVarsToCms', $aParams['bToxidDontPassPostVarsToCms'], $sShopId, self::CONFIG_MODULE_NAME );
     }

--- a/controller/admin/toxid_setup_main.php
+++ b/controller/admin/toxid_setup_main.php
@@ -21,6 +21,7 @@ class toxid_setup_main extends oxAdminView
         $this->_aViewData['toxidRewriteUrlEncoded']        = $oConf->getShopConfVar('toxidRewriteUrlEncoded');
         $this->_aViewData['toxidDontRewriteUrls']          = $oConf->getShopConfVar('toxidDontRewriteUrls');
         $this->_aViewData['bToxidDontPassPostVarsToCms']   = $oConf->getShopConfVar('bToxidDontPassPostVarsToCms');
+        $this->_aViewData['bToxidRedirect301ToStartpage']  = $oConf->getShopConfVar('bToxidRedirect301ToStartpage');
 
         return parent::render();
     }
@@ -45,5 +46,6 @@ class toxid_setup_main extends oxAdminView
         $oConf->saveShopConfVar( 'bl', 'toxidRewriteUrlEncoded', $aParams['toxidRewriteUrlEncoded'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'bl', 'toxidDontRewriteUrls', $aParams['toxidDontRewriteUrls'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'bl', 'bToxidDontPassPostVarsToCms', $aParams['bToxidDontPassPostVarsToCms'], $sShopId, self::CONFIG_MODULE_NAME );
+        $oConf->saveShopConfVar( 'bl', 'bToxidRedirect301ToStartpage', $aParams['bToxidRedirect301ToStartpage'], $sShopId, self::CONFIG_MODULE_NAME );
     }
 }

--- a/controller/admin/toxid_setup_main.php
+++ b/controller/admin/toxid_setup_main.php
@@ -11,15 +11,16 @@ class toxid_setup_main extends oxAdminView
     {
         $oConf = oxRegistry::getConfig();
 
-        $this->_aViewData['aToxidCurlSource']            = $oConf->getShopConfVar('aToxidCurlSource');
-        $this->_aViewData['aToxidCurlSourceSsl']         = $oConf->getShopConfVar('aToxidCurlSourceSsl');
-        $this->_aViewData['aToxidSearchUrl']             = $oConf->getShopConfVar('aToxidSearchUrl');
-        $this->_aViewData['aToxidCurlUrlParams']         = $oConf->getShopConfVar('aToxidCurlUrlParams');
-        $this->_aViewData['aToxidCurlSeoSnippets']       = $oConf->getShopConfVar('aToxidCurlSeoSnippets');
-        $this->_aViewData['toxidDontRewriteRelUrls']     = $oConf->getShopConfVar('toxidDontRewriteRelUrls');
-        $this->_aViewData['toxidRewriteUrlEncoded']      = $oConf->getShopConfVar('toxidRewriteUrlEncoded');
-        $this->_aViewData['toxidDontRewriteUrls']        = $oConf->getShopConfVar('toxidDontRewriteUrls');
-        $this->_aViewData['bToxidDontPassPostVarsToCms'] = $oConf->getShopConfVar('bToxidDontPassPostVarsToCms');
+        $this->_aViewData['aToxidCurlSource']              = $oConf->getShopConfVar('aToxidCurlSource');
+        $this->_aViewData['aToxidCurlSourceSsl']           = $oConf->getShopConfVar('aToxidCurlSourceSsl');
+        $this->_aViewData['aToxidSearchUrl']               = $oConf->getShopConfVar('aToxidSearchUrl');
+        $this->_aViewData['aToxidCurlUrlParams']           = $oConf->getShopConfVar('aToxidCurlUrlParams');
+        $this->_aViewData['aToxidCurlSeoSnippets']         = $oConf->getShopConfVar('aToxidCurlSeoSnippets');
+        $this->_aViewData['toxidDontRewriteRelUrls']       = $oConf->getShopConfVar('toxidDontRewriteRelUrls');
+        $this->_aViewData['toxidDontRewriteFileExtension'] = $oConf->getShopConfVar('toxidDontRewriteFileExtension');
+        $this->_aViewData['toxidRewriteUrlEncoded']        = $oConf->getShopConfVar('toxidRewriteUrlEncoded');
+        $this->_aViewData['toxidDontRewriteUrls']          = $oConf->getShopConfVar('toxidDontRewriteUrls');
+        $this->_aViewData['bToxidDontPassPostVarsToCms']   = $oConf->getShopConfVar('bToxidDontPassPostVarsToCms');
 
         return parent::render();
     }
@@ -40,6 +41,7 @@ class toxid_setup_main extends oxAdminView
         $oConf->saveShopConfVar( 'arr', 'aToxidCurlUrlParams', $aParams['aToxidCurlUrlParams'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'arr', 'aToxidCurlSeoSnippets', $aParams['aToxidCurlSeoSnippets'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'str', 'toxidDontRewriteRelUrls', $aParams['toxidDontRewriteRelUrls'], $sShopId, self::CONFIG_MODULE_NAME );
+        $oConf->saveShopConfVar( 'str', 'toxidDontRewriteFileExtension', $aParams['toxidDontRewriteFileExtension'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'bl', 'toxidRewriteUrlEncoded', $aParams['toxidRewriteUrlEncoded'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'bl', 'toxidDontRewriteUrls', $aParams['toxidDontRewriteUrls'], $sShopId, self::CONFIG_MODULE_NAME );
         $oConf->saveShopConfVar( 'bl', 'bToxidDontPassPostVarsToCms', $aParams['bToxidDontPassPostVarsToCms'], $sShopId, self::CONFIG_MODULE_NAME );

--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -298,6 +298,13 @@ class toxidCurl extends oxSuperCfg
                 header ('Location: '.$this->getConfig()->getShopHomeURL());
                 oxRegistry::getUtils()->showMessageAndExit('');
                 break;
+            case 301:
+                if($this->getConfig()->getConfigParam('bToxidRedirect301ToStartpage')) {
+                    header ("HTTP/1.1 301 Moved Permanently");
+                    header ('Location: '.$this->getToxidStartUrl());
+                    oxRegistry::getUtils()->showMessageAndExit('');
+                }
+                break;
             case 0:
                 header ('Location: '.$this->getConfig()->getShopHomeURL());
                 oxRegistry::getUtils()->showMessageAndExit('');

--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -389,7 +389,6 @@ class toxidCurl extends oxSuperCfg
 
             preg_match_all($pattern, $sContent, $matches, PREG_SET_ORDER);
             foreach ($matches as $match) {
-                error_log($match[0]);
                 if ($this->_getRelValuesForNoRewrite()) {
                     if (preg_match('%rel=["\']('.$this->_getRelValuesForNoRewrite().')["\']%', $match[0])) {
                         continue;

--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -398,8 +398,19 @@ class toxidCurl extends oxSuperCfg
                 $sContent = str_replace($match[0], str_replace($source, $target, $match[0]), $sContent);
             }
             unset($match);
-        }
 
+            if ($this->getConfig()->getConfigParam('toxidRewriteUrlEncoded') == true)
+            {
+                // rewrite url encoded url in src attribut
+                $patternUrlEncoded = '%[^<>]*src=[\'"][^\'"]+' . preg_quote(urlencode($source), '%') . '[^"\']*?(?:/|\.html|\.php|\.asp)?(?:\?[^"\']*)?[\'"][^<>]*%';
+                preg_match_all($patternUrlEncoded, $sContent, $matches, PREG_SET_ORDER);
+                foreach ($matches as $match) {
+                    $sContent = str_replace($match[0], str_replace(urlencode($source), urlencode($target), $match[0]), $sContent);
+                }
+
+                unset($match);
+            }
+        }
         return $sContent;
     }
 

--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -110,6 +110,12 @@ class toxidCurl extends oxSuperCfg
     protected $_sRelValuesForNoRewrite = null;
 
     /**
+     * stores file extension values for no url rewrite
+     * @var string
+     */
+    protected $_sFileExtensionValuesForNoRewrite = null;
+
+    /**
      * Deprecated!
      * returns a single instance of this class
      *
@@ -389,8 +395,15 @@ class toxidCurl extends oxSuperCfg
 
             preg_match_all($pattern, $sContent, $matches, PREG_SET_ORDER);
             foreach ($matches as $match) {
+                // skip rewrite for defined rel values
                 if ($this->_getRelValuesForNoRewrite()) {
                     if (preg_match('%rel=["\']('.$this->_getRelValuesForNoRewrite().')["\']%', $match[0])) {
+                        continue;
+                    }
+                }
+                // skip rewrite for defined file extensions
+                if ($this->_getFileExtensionValuesForNoRewrite()) {
+                    if (preg_match('%\.('.$this->_getFileExtensionValuesForNoRewrite().')[\'"]*%i', $match[0])) {
                         continue;
                     }
                 }
@@ -538,5 +551,18 @@ class toxidCurl extends oxSuperCfg
         }
 
         return $this->_sRelValuesForNoRewrite;
+    }
+
+    /**
+     * returns string with rel values separated by '|'
+     * @return string
+     */
+    protected function _getFileExtensionValuesForNoRewrite()
+    {
+        if ($this->_sFileExtensionValuesForNoRewrite === null) {
+            $this->_sFileExtensionValuesForNoRewrite = implode('|', explode(',',str_replace(' ', '', $this->getConfig()->getConfigParam('toxidDontRewriteFileExtension'))));
+        }
+
+        return $this->_sFileExtensionValuesForNoRewrite;
     }
 }

--- a/views/admin/de/toxid_admin_lang.php
+++ b/views/admin/de/toxid_admin_lang.php
@@ -22,6 +22,7 @@ $aLang = array(
     'TOXID_DONT_REWRITE_REL_URLS'                  => 'URLs für bestimmte "rel" Attributwerte nicht umschreiben (kommaseparierte Liste)',
     'TOXID_DONT_REWRITE_URLS_WITH_FILE_EXTENSIONS' => 'URLs für bestimmte Dateiendungen nicht umschreiben (kommaseparierte Liste)',
     'TOXID_REWRITE_URLENCODED'                     => 'URLs die "url encoded" sind umschreiben (URL muss sich im "src" attribut befindet)',
+    'TOXID_REDIRECT_301_TO_STARTPAGE'              => 'Auf Startseite weiterleiten wenn das CMS den HTTP-Statuscode 301 liefert',
     'TOXID_LOOKING_FOR'                            => 'gesucht!',
     'TOXID_GENERAL'                                => 'Allgemein',
     'TOXID_BECOME_PARTNER'                         => 'Partner werden',

--- a/views/admin/de/toxid_admin_lang.php
+++ b/views/admin/de/toxid_admin_lang.php
@@ -20,6 +20,7 @@ $aLang = array(
     'TOXID_DONT_REWRITE'          => 'URLs nicht umschreiben - Aufrufe führen auf externe CMS-Seite',
     'TOXID_DONT_PASSTHROUGH'      => 'POST-Parameter <b><u>nicht</u></b> an CMS durchreichen',
     'TOXID_DONT_REWRITE_REL_URLS' => 'URLs für bestimmte "rel" Attributwerte nicht umschreiben (kommaseparierte Liste)',
+    'TOXID_REWRITE_URLENCODED'    => 'URLs die "url encoded" sind umschreiben (URL muss sich im "src" attribut befindet)',
     'TOXID_LOOKING_FOR'           => 'gesucht!',
     'TOXID_GENERAL'               => 'Allgemein',
     'TOXID_BECOME_PARTNER'        => 'Partner werden',

--- a/views/admin/de/toxid_admin_lang.php
+++ b/views/admin/de/toxid_admin_lang.php
@@ -3,28 +3,29 @@
 $sLangName  = "Deutsch";
 
 $aLang = array(
-    'charset'                     => 'UTF-8',
-    'toxid_setup'                 => 'TOXID Einstellungen',
-    'toxid_setup_main'            => 'TOXID Grundeinstellungen',
-    'TOXID_SUPPORT_HEADLINE'      => 'TOXID unterstützen',
-    'TOXID_SUPPORT_DESC'          => 'TOXID cURL ist ein OpenSource Projekt, ursprünglich entwickelt von Joscha Krug. 
-                                      Die Entwicklung wird von seiner Agentur, der <b><a href="http://www.marmalade.de/?pk_campaign=toxidBackend&pk_kwd=Textlink" target="_blank">marmalade GmbH</a></b>, fortgesetzt.
-                                      Wir freuen uns über Unterstützung, am liebsten <b><a href="https://github.com/jkrug/TOXID-cURL/" target="_blank">in Form von Code</a></b>,
-                                      aber natürlich trägt auch ein finanzielle Unterstützung zur Wartung, 
-                                      Pflege und Entwicklung neuer Features bei.',
-    'TOXID_SOURCE'                => 'CMS URL',
-    'TOXID_SOURCE_SSL'            => 'CMS SSL-URL',
-    'TOXID_SEO_SNIPPET'           => 'URL Identifier / SEO-Snippet',
-    'TOXID_SEARCH_URL'            => 'URL zum Aufruf der Suche (optional)',
-    'TOXID_PARAM'                 => 'TOXID URL-Parameter',
-    'TOXID_DONT_REWRITE'          => 'URLs nicht umschreiben - Aufrufe führen auf externe CMS-Seite',
-    'TOXID_DONT_PASSTHROUGH'      => 'POST-Parameter <b><u>nicht</u></b> an CMS durchreichen',
-    'TOXID_DONT_REWRITE_REL_URLS' => 'URLs für bestimmte "rel" Attributwerte nicht umschreiben (kommaseparierte Liste)',
-    'TOXID_REWRITE_URLENCODED'    => 'URLs die "url encoded" sind umschreiben (URL muss sich im "src" attribut befindet)',
-    'TOXID_LOOKING_FOR'           => 'gesucht!',
-    'TOXID_GENERAL'               => 'Allgemein',
-    'TOXID_BECOME_PARTNER'        => 'Partner werden',
-    'TOXID_INTEGRATIONPARTNER'    => 'Integrationspartner',
+    'charset'                                      => 'UTF-8',
+    'toxid_setup'                                  => 'TOXID Einstellungen',
+    'toxid_setup_main'                             => 'TOXID Grundeinstellungen',
+    'TOXID_SUPPORT_HEADLINE'                       => 'TOXID unterstützen',
+    'TOXID_SUPPORT_DESC'                           => 'TOXID cURL ist ein OpenSource Projekt, ursprünglich entwickelt von Joscha Krug. 
+                                                       Die Entwicklung wird von seiner Agentur, der <b><a href="http://www.marmalade.de/?pk_campaign=toxidBackend&pk_kwd=Textlink" target="_blank">marmalade GmbH</a></b>, fortgesetzt.
+                                                       Wir freuen uns über Unterstützung, am liebsten <b><a href="https://github.com/jkrug/TOXID-cURL/" target="_blank">in Form von Code</a></b>,
+                                                       aber natürlich trägt auch ein finanzielle Unterstützung zur Wartung, 
+                                                       Pflege und Entwicklung neuer Features bei.',
+    'TOXID_SOURCE'                                 => 'CMS URL',
+    'TOXID_SOURCE_SSL'                             => 'CMS SSL-URL',
+    'TOXID_SEO_SNIPPET'                            => 'URL Identifier / SEO-Snippet',
+    'TOXID_SEARCH_URL'                             => 'URL zum Aufruf der Suche (optional)',
+    'TOXID_PARAM'                                  => 'TOXID URL-Parameter',
+    'TOXID_DONT_REWRITE'                           => 'URLs nicht umschreiben - Aufrufe führen auf externe CMS-Seite',
+    'TOXID_DONT_PASSTHROUGH'                       => 'POST-Parameter <b><u>nicht</u></b> an CMS durchreichen',
+    'TOXID_DONT_REWRITE_REL_URLS'                  => 'URLs für bestimmte "rel" Attributwerte nicht umschreiben (kommaseparierte Liste)',
+    'TOXID_DONT_REWRITE_URLS_WITH_FILE_EXTENSIONS' => 'URLs für bestimmte Dateiendungen nicht umschreiben (kommaseparierte Liste)',
+    'TOXID_REWRITE_URLENCODED'                     => 'URLs die "url encoded" sind umschreiben (URL muss sich im "src" attribut befindet)',
+    'TOXID_LOOKING_FOR'                            => 'gesucht!',
+    'TOXID_GENERAL'                                => 'Allgemein',
+    'TOXID_BECOME_PARTNER'                         => 'Partner werden',
+    'TOXID_INTEGRATIONPARTNER'                     => 'Integrationspartner',
 );
 
 if (oxRegistry::getConfig()->getConfigParam('iUtfMode') === 0) {

--- a/views/admin/de/toxid_admin_lang.php
+++ b/views/admin/de/toxid_admin_lang.php
@@ -3,26 +3,27 @@
 $sLangName  = "Deutsch";
 
 $aLang = array(
-    'charset'                   => 'UTF-8',
-    'toxid_setup'               => 'TOXID Einstellungen',
-    'toxid_setup_main'          => 'TOXID Grundeinstellungen',
-    'TOXID_SUPPORT_HEADLINE'    => 'TOXID unterstützen',
-    'TOXID_SUPPORT_DESC'        => 'TOXID cURL ist ein OpenSource Projekt, ursprünglich entwickelt von Joscha Krug. 
-                                    Die Entwicklung wird von seiner Agentur, der <b><a href="http://www.marmalade.de/?pk_campaign=toxidBackend&pk_kwd=Textlink" target="_blank">marmalade GmbH</a></b>, fortgesetzt.
-                                    Wir freuen uns über Unterstützung, am liebsten <b><a href="https://github.com/jkrug/TOXID-cURL/" target="_blank">in Form von Code</a></b>,
-                                    aber natürlich trägt auch ein finanzielle Unterstützung zur Wartung, 
-                                    Pflege und Entwicklung neuer Features bei.',
-    'TOXID_SOURCE'              => 'CMS URL',
-    'TOXID_SOURCE_SSL'          => 'CMS SSL-URL',
-    'TOXID_SEO_SNIPPET'         => 'URL Identifier / SEO-Snippet',
-    'TOXID_SEARCH_URL'          => 'URL zum Aufruf der Suche (optional)',
-    'TOXID_PARAM'               => 'TOXID URL-Parameter',
-    'TOXID_DONT_REWRITE'        => 'URLs nicht umschreiben - Aufrufe führen auf externe CMS-Seite',
-    'TOXID_DONT_PASSTHROUGH'    => 'POST-Parameter <b><u>nicht</u></b> an CMS durchreichen',
-    'TOXID_LOOKING_FOR'         => 'gesucht!',
-    'TOXID_GENERAL'             => 'Allgemein',
-    'TOXID_BECOME_PARTNER'      => 'Partner werden',
-    'TOXID_INTEGRATIONPARTNER'  => 'Integrationspartner',
+    'charset'                     => 'UTF-8',
+    'toxid_setup'                 => 'TOXID Einstellungen',
+    'toxid_setup_main'            => 'TOXID Grundeinstellungen',
+    'TOXID_SUPPORT_HEADLINE'      => 'TOXID unterstützen',
+    'TOXID_SUPPORT_DESC'          => 'TOXID cURL ist ein OpenSource Projekt, ursprünglich entwickelt von Joscha Krug. 
+                                      Die Entwicklung wird von seiner Agentur, der <b><a href="http://www.marmalade.de/?pk_campaign=toxidBackend&pk_kwd=Textlink" target="_blank">marmalade GmbH</a></b>, fortgesetzt.
+                                      Wir freuen uns über Unterstützung, am liebsten <b><a href="https://github.com/jkrug/TOXID-cURL/" target="_blank">in Form von Code</a></b>,
+                                      aber natürlich trägt auch ein finanzielle Unterstützung zur Wartung, 
+                                      Pflege und Entwicklung neuer Features bei.',
+    'TOXID_SOURCE'                => 'CMS URL',
+    'TOXID_SOURCE_SSL'            => 'CMS SSL-URL',
+    'TOXID_SEO_SNIPPET'           => 'URL Identifier / SEO-Snippet',
+    'TOXID_SEARCH_URL'            => 'URL zum Aufruf der Suche (optional)',
+    'TOXID_PARAM'                 => 'TOXID URL-Parameter',
+    'TOXID_DONT_REWRITE'          => 'URLs nicht umschreiben - Aufrufe führen auf externe CMS-Seite',
+    'TOXID_DONT_PASSTHROUGH'      => 'POST-Parameter <b><u>nicht</u></b> an CMS durchreichen',
+    'TOXID_DONT_REWRITE_REL_URLS' => 'URLs für bestimmte "rel" Attributwerte nicht umschreiben (kommaseparierte Liste)',
+    'TOXID_LOOKING_FOR'           => 'gesucht!',
+    'TOXID_GENERAL'               => 'Allgemein',
+    'TOXID_BECOME_PARTNER'        => 'Partner werden',
+    'TOXID_INTEGRATIONPARTNER'    => 'Integrationspartner',
 );
 
 if (oxRegistry::getConfig()->getConfigParam('iUtfMode') === 0) {

--- a/views/admin/en/toxid_admin_lang.php
+++ b/views/admin/en/toxid_admin_lang.php
@@ -20,6 +20,7 @@ $aLang = array(
     'TOXID_DONT_REWRITE'          => 'Don\'t rewrite the URLs - Users will linked to the external site.',
     'TOXID_DONT_PASSTHROUGH'      => '<b><u>Don\'t</u></b> pass POST parameters to CMS',
     'TOXID_DONT_REWRITE_REL_URLS' => 'Don\'t rewrite the URLs for particular "rel" attribute values (comma-separated list)',
+    'TOXID_REWRITE_URLENCODED'    => 'Rewrite URLs that are "url encoded" (URL must be contained in the "src" attribute)',
     'TOXID_LOOKING_FOR'           => 'Support us with PayPal!',
     'TOXID_GENERAL'               => 'General',
     'TOXID_BECOME_PARTNER'        => 'Become a partner',

--- a/views/admin/en/toxid_admin_lang.php
+++ b/views/admin/en/toxid_admin_lang.php
@@ -3,28 +3,29 @@
 $sLangName  = "Deutsch";
 
 $aLang = array(
-    'charset'                     => 'UTF-8',
-    'toxid_setup'                 => 'TOXID Configuration',
-    'toxid_setup_main'            => 'TOXID Basic settings',
-    'TOXID_SUPPORT_HEADLINE'      => 'Support the TOXID project',
-    'TOXID_SUPPORT_DESC'          => 'TOXID cURL ist ein OpenSource Projekt, ursprünglich entwickelt von Joscha Krug. 
-                                      Die Entwicklung wird von seiner Agentur, der <b><a href="http://www.marmalade.de/?pk_campaign=toxidBackend&pk_kwd=Textlink" target="_blank">marmalade GmbH</a></b>, fortgesetzt.
-                                      Wir freuen uns über Unterstützung, am liebsten <b><a href="https://github.com/jkrug/TOXID-cURL/" target="_blank">in Form von Code</a></b>,
-                                      aber natürlich trägt auch ein finanzielle Unterstützung zur Wartung, 
-                                      Pflege und Entwicklung neuer Features bei.',
-    'TOXID_SOURCE'                => 'CMS URL',
-    'TOXID_SOURCE_SSL'            => 'CMS SSL-URL',
-    'TOXID_SEO_SNIPPET'           => 'URL Identifier / SEO-Snippet',
-    'TOXID_SEARCH_URL'            => 'URL to call the searchpage (optional)',
-    'TOXID_PARAM'                 => 'TOXID URL parameter',
-    'TOXID_DONT_REWRITE'          => 'Don\'t rewrite the URLs - Users will linked to the external site.',
-    'TOXID_DONT_PASSTHROUGH'      => '<b><u>Don\'t</u></b> pass POST parameters to CMS',
-    'TOXID_DONT_REWRITE_REL_URLS' => 'Don\'t rewrite the URLs for particular "rel" attribute values (comma-separated list)',
-    'TOXID_REWRITE_URLENCODED'    => 'Rewrite URLs that are "url encoded" (URL must be contained in the "src" attribute)',
-    'TOXID_LOOKING_FOR'           => 'Support us with PayPal!',
-    'TOXID_GENERAL'               => 'General',
-    'TOXID_BECOME_PARTNER'        => 'Become a partner',
-    'TOXID_INTEGRATIONPARTNER'    => 'Integration partners',
+    'charset'                                      => 'UTF-8',
+    'toxid_setup'                                  => 'TOXID Configuration',
+    'toxid_setup_main'                             => 'TOXID Basic settings',
+    'TOXID_SUPPORT_HEADLINE'                       => 'Support the TOXID project',
+    'TOXID_SUPPORT_DESC'                           => 'TOXID cURL ist ein OpenSource Projekt, ursprünglich entwickelt von Joscha Krug. 
+                                                       Die Entwicklung wird von seiner Agentur, der <b><a href="http://www.marmalade.de/?pk_campaign=toxidBackend&pk_kwd=Textlink" target="_blank">marmalade GmbH</a></b>, fortgesetzt.
+                                                       Wir freuen uns über Unterstützung, am liebsten <b><a href="https://github.com/jkrug/TOXID-cURL/" target="_blank">in Form von Code</a></b>,
+                                                       aber natürlich trägt auch ein finanzielle Unterstützung zur Wartung, 
+                                                       Pflege und Entwicklung neuer Features bei.',
+    'TOXID_SOURCE'                                 => 'CMS URL',
+    'TOXID_SOURCE_SSL'                             => 'CMS SSL-URL',
+    'TOXID_SEO_SNIPPET'                            => 'URL Identifier / SEO-Snippet',
+    'TOXID_SEARCH_URL'                             => 'URL to call the searchpage (optional)',
+    'TOXID_PARAM'                                  => 'TOXID URL parameter',
+    'TOXID_DONT_REWRITE'                           => 'Don\'t rewrite the URLs - Users will linked to the external site.',
+    'TOXID_DONT_PASSTHROUGH'                       => '<b><u>Don\'t</u></b> pass POST parameters to CMS',
+    'TOXID_DONT_REWRITE_REL_URLS'                  => 'Don\'t rewrite the URLs for particular "rel" attribute values (comma-separated list)',
+    'TOXID_DONT_REWRITE_URLS_WITH_FILE_EXTENSIONS' => 'Don\'t rewrite the URLs for particular file extensions (comma-separated list)',
+    'TOXID_REWRITE_URLENCODED'                     => 'Rewrite URLs that are "url encoded" (URL must be contained in the "src" attribute)',
+    'TOXID_LOOKING_FOR'                            => 'Support us with PayPal!',
+    'TOXID_GENERAL'                                => 'General',
+    'TOXID_BECOME_PARTNER'                         => 'Become a partner',
+    'TOXID_INTEGRATIONPARTNER'                     => 'Integration partners',
 );
 
 if (oxRegistry::getConfig()->getConfigParam('iUtfMode') === 0) {

--- a/views/admin/en/toxid_admin_lang.php
+++ b/views/admin/en/toxid_admin_lang.php
@@ -3,26 +3,27 @@
 $sLangName  = "Deutsch";
 
 $aLang = array(
-    'charset'                   => 'UTF-8',
-    'toxid_setup'               => 'TOXID Configuration',
-    'toxid_setup_main'          => 'TOXID Basic settings',
-    'TOXID_SUPPORT_HEADLINE'    => 'Support the TOXID project',
-    'TOXID_SUPPORT_DESC'        => 'TOXID cURL ist ein OpenSource Projekt, ursprünglich entwickelt von Joscha Krug. 
-                                    Die Entwicklung wird von seiner Agentur, der <b><a href="http://www.marmalade.de/?pk_campaign=toxidBackend&pk_kwd=Textlink" target="_blank">marmalade GmbH</a></b>, fortgesetzt.
-                                    Wir freuen uns über Unterstützung, am liebsten <b><a href="https://github.com/jkrug/TOXID-cURL/" target="_blank">in Form von Code</a></b>,
-                                    aber natürlich trägt auch ein finanzielle Unterstützung zur Wartung, 
-                                    Pflege und Entwicklung neuer Features bei.',
-    'TOXID_SOURCE'              => 'CMS URL',
-    'TOXID_SOURCE_SSL'          => 'CMS SSL-URL',
-    'TOXID_SEO_SNIPPET'         => 'URL Identifier / SEO-Snippet',
-    'TOXID_SEARCH_URL'          => 'URL to call the searchpage (optional)',
-    'TOXID_PARAM'               => 'TOXID URL parameter',
-    'TOXID_DONT_REWRITE'        => 'Don\'t rewrite the URLs - Users will linked to the external site.',
-    'TOXID_DONT_PASSTHROUGH'    => '<b><u>Don\'t</u></b> pass POST parameters to CMS',
-    'TOXID_LOOKING_FOR'         => 'Support us with PayPal!',
-    'TOXID_GENERAL'             => 'General',
-    'TOXID_BECOME_PARTNER'      => 'Become a partner',
-    'TOXID_INTEGRATIONPARTNER'  => 'Integration partners',
+    'charset'                     => 'UTF-8',
+    'toxid_setup'                 => 'TOXID Configuration',
+    'toxid_setup_main'            => 'TOXID Basic settings',
+    'TOXID_SUPPORT_HEADLINE'      => 'Support the TOXID project',
+    'TOXID_SUPPORT_DESC'          => 'TOXID cURL ist ein OpenSource Projekt, ursprünglich entwickelt von Joscha Krug. 
+                                      Die Entwicklung wird von seiner Agentur, der <b><a href="http://www.marmalade.de/?pk_campaign=toxidBackend&pk_kwd=Textlink" target="_blank">marmalade GmbH</a></b>, fortgesetzt.
+                                      Wir freuen uns über Unterstützung, am liebsten <b><a href="https://github.com/jkrug/TOXID-cURL/" target="_blank">in Form von Code</a></b>,
+                                      aber natürlich trägt auch ein finanzielle Unterstützung zur Wartung, 
+                                      Pflege und Entwicklung neuer Features bei.',
+    'TOXID_SOURCE'                => 'CMS URL',
+    'TOXID_SOURCE_SSL'            => 'CMS SSL-URL',
+    'TOXID_SEO_SNIPPET'           => 'URL Identifier / SEO-Snippet',
+    'TOXID_SEARCH_URL'            => 'URL to call the searchpage (optional)',
+    'TOXID_PARAM'                 => 'TOXID URL parameter',
+    'TOXID_DONT_REWRITE'          => 'Don\'t rewrite the URLs - Users will linked to the external site.',
+    'TOXID_DONT_PASSTHROUGH'      => '<b><u>Don\'t</u></b> pass POST parameters to CMS',
+    'TOXID_DONT_REWRITE_REL_URLS' => 'Don\'t rewrite the URLs for particular "rel" attribute values (comma-separated list)',
+    'TOXID_LOOKING_FOR'           => 'Support us with PayPal!',
+    'TOXID_GENERAL'               => 'General',
+    'TOXID_BECOME_PARTNER'        => 'Become a partner',
+    'TOXID_INTEGRATIONPARTNER'    => 'Integration partners',
 );
 
 if (oxRegistry::getConfig()->getConfigParam('iUtfMode') === 0) {

--- a/views/admin/en/toxid_admin_lang.php
+++ b/views/admin/en/toxid_admin_lang.php
@@ -22,6 +22,7 @@ $aLang = array(
     'TOXID_DONT_REWRITE_REL_URLS'                  => 'Don\'t rewrite the URLs for particular "rel" attribute values (comma-separated list)',
     'TOXID_DONT_REWRITE_URLS_WITH_FILE_EXTENSIONS' => 'Don\'t rewrite the URLs for particular file extensions (comma-separated list)',
     'TOXID_REWRITE_URLENCODED'                     => 'Rewrite URLs that are "url encoded" (URL must be contained in the "src" attribute)',
+    'TOXID_REDIRECT_301_TO_STARTPAGE'              => 'Redirect to home page if the CMS returns the HTTP status code 301',
     'TOXID_LOOKING_FOR'                            => 'Support us with PayPal!',
     'TOXID_GENERAL'                                => 'General',
     'TOXID_BECOME_PARTNER'                         => 'Become a partner',

--- a/views/admin/tpl/toxid_setup_main.tpl
+++ b/views/admin/tpl/toxid_setup_main.tpl
@@ -144,6 +144,13 @@ function _groupExp(el) {
                             </tr>
                             <tr>
                                 <td valign="top" class="edittext">
+                                    <input type="hidden" name="editval[toxidRewriteUrlEncoded]" value="0">
+                                    <input type="checkbox" name="editval[toxidRewriteUrlEncoded]" value="1" [{if $toxidRewriteUrlEncoded}]checked="checked"[{/if}]>
+                                    [{oxmultilang ident="TOXID_REWRITE_URLENCODED"}]
+                                </td>
+                            </tr>
+                            <tr>
+                                <td valign="top" class="edittext">
                                     <input type="hidden" name="editval[toxidDontRewriteUrls]" value="0">
                                     <input type="checkbox" name="editval[toxidDontRewriteUrls]" value="1" [{if $toxidDontRewriteUrls}]checked="checked"[{/if}]>
                                     [{oxmultilang ident="TOXID_DONT_REWRITE"}]

--- a/views/admin/tpl/toxid_setup_main.tpl
+++ b/views/admin/tpl/toxid_setup_main.tpl
@@ -171,6 +171,13 @@ function _groupExp(el) {
                                     [{oxmultilang ident="TOXID_DONT_PASSTHROUGH"}]
                                 </td>
                             </tr>
+                            <tr>
+                                <td valign="top" class="edittext">
+                                    <input type="hidden" name="editval[bToxidRedirect301ToStartpage]" value="0">
+                                    <input type="checkbox" name="editval[bToxidRedirect301ToStartpage]" value="1" [{if $bToxidRedirect301ToStartpage}]checked="checked"[{/if}]>
+                                    [{oxmultilang ident="TOXID_REDIRECT_301_TO_STARTPAGE"}]
+                                </td>
+                            </tr>
                         </table>
                     </fieldset>
                 </dd>

--- a/views/admin/tpl/toxid_setup_main.tpl
+++ b/views/admin/tpl/toxid_setup_main.tpl
@@ -136,6 +136,14 @@ function _groupExp(el) {
                         <table>
                             <tr>
                                 <td valign="top" class="edittext">
+                                    [{oxmultilang ident="TOXID_DONT_REWRITE_REL_URLS"}]:
+                                </td>
+                                <td valign="top" class="edittext">
+                                    <input type="text" name="editval[toxidDontRewriteRelUrls]" value="[{$toxidDontRewriteRelUrls}]" size="100">
+                                </td>
+                            </tr>
+                            <tr>
+                                <td valign="top" class="edittext">
                                     <input type="hidden" name="editval[toxidDontRewriteUrls]" value="0">
                                     <input type="checkbox" name="editval[toxidDontRewriteUrls]" value="1" [{if $toxidDontRewriteUrls}]checked="checked"[{/if}]>
                                     [{oxmultilang ident="TOXID_DONT_REWRITE"}]

--- a/views/admin/tpl/toxid_setup_main.tpl
+++ b/views/admin/tpl/toxid_setup_main.tpl
@@ -144,6 +144,14 @@ function _groupExp(el) {
                             </tr>
                             <tr>
                                 <td valign="top" class="edittext">
+                                    [{oxmultilang ident="TOXID_DONT_REWRITE_URLS_WITH_FILE_EXTENSIONS"}]:
+                                </td>
+                                <td valign="top" class="edittext">
+                                    <input type="text" name="editval[toxidDontRewriteFileExtension]" value="[{$toxidDontRewriteFileExtension}]" size="100">
+                                </td>
+                            </tr>
+                            <tr>
+                                <td valign="top" class="edittext">
                                     <input type="hidden" name="editval[toxidRewriteUrlEncoded]" value="0">
                                     <input type="checkbox" name="editval[toxidRewriteUrlEncoded]" value="1" [{if $toxidRewriteUrlEncoded}]checked="checked"[{/if}]>
                                     [{oxmultilang ident="TOXID_REWRITE_URLENCODED"}]


### PR DESCRIPTION
Neue Moduleinstellungen:
-URLs für bestimmte "rel" Attributwerte nicht umschreiben (für CSS)
-URLs für bestimmte Dateiendungen nicht umschreiben (für lightboxen)
-URLs die "url encoded" sind umschreiben (für Social Media Buttons)
-Auf Startseite weiterleiten wenn das CMS den HTTP-Statuscode 301 liefert (wenn Seite im CMS nicht vorhanden ist)