### PR TITLE
Add preview option to wordpress plugin

### DIFF
--- a/CMS-templates/Wordpress/wp-content/plugins/toxid/theme-switcher.php
+++ b/CMS-templates/Wordpress/wp-content/plugins/toxid/theme-switcher.php
@@ -4,7 +4,7 @@
 Plugin Name: TOXID Themeswitcher
 Plugin URI: http://toxid.org/
 Description: Switch theme for TOXID-cURL.
-Version: 1.0
+Version: 1.1
 Author: Joscha Krug
 Author URI: http://www.marmalade.de
 
@@ -19,59 +19,88 @@ http://ryan.boren.me/
 
 class ThemeSwitcher {
 
-	function ThemeSwitcher()
-	{		
-		add_filter('stylesheet', array(&$this, 'get_stylesheet'));
-		add_filter('template', array(&$this, 'get_template'));
-	}
-	
-	function get_stylesheet($stylesheet = '') {
-		$theme = $this->get_theme();
+    function ThemeSwitcher()
+    {       
+        add_filter('stylesheet', array(&$this, 'get_stylesheet'));
+        add_filter('template', array(&$this, 'get_template'));
+        add_filter('preview_page_link', array(&$this, 'add_preview_theme'));
+        add_filter('preview_post_link', array(&$this, 'add_preview_theme'));
+        add_action('admin_init', array(&$this, 'init_admin'));
+    }
+    
+    function add_preview_theme($link)
+    {
+        $theme = urlencode(get_option('toxid_preview_theme'));
+        $link .= (strpos($link, '?') === false ? '?' : '&') . 'wptheme=' . $theme;
+        return $link;
+    }
+    
+    function init_admin()
+    {
+        register_setting('general', 'toxid_preview_theme');
+        add_settings_section('toxid-settings', 'TOXID', '__return_false', 'general');
+        add_settings_field('toxid_preview_theme', 'Theme used for previews', array(&$this, 'admin_toxid_preview_theme_field'), 'general', 'toxid-settings');
+    }
+    
+    function admin_toxid_preview_theme_field()
+    {
+        $themes = array_keys(get_themes());
+        $currentTheme = get_option('toxid_preview_theme');
+        echo '<select name="toxid_preview_theme">';
+        echo '<option>' . __('None') . '</option>';
+        foreach ($themes as $theme) {
+            printf('<option value="%s" %s>%s</option>', esc_attr($theme), ($theme == $currentTheme ? 'selected' : ''), esc_html($theme));
+        }
+        echo '</select>';
+    }
+    
+    function get_stylesheet($stylesheet = '') {
+        $theme = $this->get_theme();
 
-		if (empty($theme)) {
-			return $stylesheet;
-		}
+        if (empty($theme)) {
+            return $stylesheet;
+        }
 
-		$theme = get_theme($theme);
+        $theme = get_theme($theme);
 
-		// Don't let people peek at unpublished themes.
-		if (isset($theme['Status']) && $theme['Status'] != 'publish')
-			return $template;		
-		
-		if (empty($theme)) {
-			return $stylesheet;
-		}
+        // Don't let people peek at unpublished themes.
+        if (isset($theme['Status']) && $theme['Status'] != 'publish')
+            return $template;
+        
+        if (empty($theme)) {
+            return $stylesheet;
+        }
 
-		return $theme['Stylesheet'];
-	}
+        return $theme['Stylesheet'];
+    }
 
-	function get_template($template) {
-		$theme = $this->get_theme();
+    function get_template($template) {
+        $theme = $this->get_theme();
 
-		if (empty($theme)) {
-			return $template;
-		}
+        if (empty($theme)) {
+            return $template;
+        }
 
-		$theme = get_theme($theme);
-		
-		if ( empty( $theme ) ) {
-			return $template;
-		}
+        $theme = get_theme($theme);
+        
+        if ( empty( $theme ) ) {
+            return $template;
+        }
 
-		// Don't let people peek at unpublished themes.
-		if (isset($theme['Status']) && $theme['Status'] != 'publish')
-			return $template;		
+        // Don't let people peek at unpublished themes.
+        if (isset($theme['Status']) && $theme['Status'] != 'publish')
+            return $template;       
 
-		return $theme['Template'];
-	}
+        return $theme['Template'];
+    }
 
-	function get_theme() {
-		if ( ! empty($_GET["wptheme"] ) ) {
-			return $_GET["wptheme"];
-		} else {
-			return '';
-		}
-	}
+    function get_theme() {
+        if ( ! empty($_GET["wptheme"] ) ) {
+            return $_GET["wptheme"];
+        } else {
+            return '';
+        }
+    }
 }
 
 $theme_switcher = new ThemeSwitcher();


### PR DESCRIPTION
On a couple of setups wordpress is set to use a "Welcome, go here" theme as default, breaking the original preview workflow. This patch adds an option to __Settings >> General__ to select a different theme to be used with previews.