### PR TITLE
Some Bugfixes

### DIFF
--- a/core/facades/toxid_curl_smarty_parser.php
+++ b/core/facades/toxid_curl_smarty_parser.php
@@ -4,7 +4,7 @@ class Toxid_Curl_Smarty_Parser
 {
     public function parse($content)
     {
-        return oxRegistry::get('oxUtilsView')->parseThroughSmarty($content);
+        return oxRegistry::get('oxUtilsView')->parseThroughSmarty($content, md5($content));
     }
 }
 

--- a/core/toxid_curl_oxviewconfig.php
+++ b/core/toxid_curl_oxviewconfig.php
@@ -45,7 +45,7 @@ class toxid_curl_oxviewconfig extends toxid_curl_oxviewconfig_parent
     {
         $toxidCurl = oxRegistry::get('toxidcurl');
         if (!$toxidCurl->getInitialized()) {
-            $smartyParser = new toxid_curl_smarty_parser();
+            $smartyParser = oxNew('toxid_curl_smarty_parser');
             $toxidCurl->init(
                 $smartyParser
             );

--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -637,7 +637,7 @@ class toxidCurl
      *
      * @return string
      */
-    private function prepareRedirectUrl($sUrl)
+    protected function prepareRedirectUrl($sUrl)
     {
         $aLangSource = $this->getConfig()->getConfigParam('aToxidCurlSource');
         $iLangId     = $this->getBaseLanguage();
@@ -654,7 +654,7 @@ class toxidCurl
      *
      * @return bool
      */
-    private function isToxidCurlPage()
+    protected function isToxidCurlPage()
     {
         return 'toxid_curl' == $this->getConfig()->getActiveView()->getClassName();
     }
@@ -664,7 +664,7 @@ class toxidCurl
      *
      * @return integer
      */
-    private function getBaseLanguage()
+    protected function getBaseLanguage()
     {
         if ($this->iLangId === null) {
             $this->iLangId = oxRegistry::getLang()->getBaseLanguage();
@@ -682,7 +682,7 @@ class toxidCurl
      *
      * @return string
      */
-    private function replaceNonSslUrls($sText, $sSslUrl, $oldSrc)
+    protected function replaceNonSslUrls($sText, $sSslUrl, $oldSrc)
     {
         if (!empty($sSslUrl)) {
 
@@ -701,7 +701,7 @@ class toxidCurl
      *
      * @return oxConfig
      */
-    private function getConfig()
+    protected function getConfig()
     {
         return oxRegistry::getConfig();
     }
@@ -728,7 +728,7 @@ class toxidCurl
 
     }
 
-    private function getCacheLifetime($iCacheTtl)
+    protected function getCacheLifetime($iCacheTtl)
     {
         if (null === $iCacheTtl) {
             $defaultCacheTtl = $this->getConfig()->getConfigParam('toxidCacheTtl');
@@ -740,7 +740,7 @@ class toxidCurl
         return $iCacheTtl;
     }
 
-    private function getCacheIdent($snippet, $sShopId, $sLangId, $blGlobalSnippet)
+    protected function getCacheIdent($snippet, $sShopId, $sLangId, $blGlobalSnippet)
     {
         $identString = $snippet;
         if (!$blGlobalSnippet) {

--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -593,7 +593,7 @@ class toxidCurl
      *
      * @return array
      */
-    private function getRemoteContentAndHandleStatusCodes($sUrl)
+    protected function getRemoteContentAndHandleStatusCodes($sUrl)
     {
         $aPage = $this->_getRemoteContent($sUrl);
         switch ($aPage['info']['http_code']) {
@@ -712,7 +712,7 @@ class toxidCurl
      * @param integer $statusCode
      * @param string  $sUrl
      */
-    private function handleError($statusCode, $sUrl = '')
+    protected function handleError($statusCode, $sUrl = '')
     {
         $this->cmsAvailable = false;
 

--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -616,6 +616,7 @@ class toxidCurl
                 }
                 break;
             case 302:
+            case 303:
             case 307:
                 $redirectUrl = $aPage['info']['redirect_url'];
                 $aPage       = $this->getRemoteContentAndHandleStatusCodes($redirectUrl);


### PR DESCRIPTION
Bugfixes:
- use oxNew for oxids autoloader and module framework instead of new for smarty parser
- use cachekey in call of oxUtilsView::parseThroughSmarty in toxid_curl smarty_parser::parse otherwise oxid will cache all these calls to the same cachekey "null"

Feature:
- functions handling status codes and errors should be customizable
- added http code 303 which is used for example by TYPO3 after form submit