### PR TITLE
fix for forwarding bug on use with wordpress toxid theme

### DIFF
--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -371,7 +371,7 @@ class toxidCurl
         $params = http_build_query($this->additionalUrlParams);
         if (false === strpos($sUrl, '?')) {
             $sUrl .= "?{$params}";
-        } else {
+        } elseif ($params!=='') {
             $sUrl = rtrim($sUrl, '&') . "&{$params}";
         }
 


### PR DESCRIPTION
without this change, i get a reload bug causing the toxid wordpress inclustion to oxid shop not to work and having an url loop like this:

www.myurl/blog/blog/blog/blog/blog/blog/blog/blog/blog/blog/blog/?wptheme=toxid


please also see: https://forum.oxid-esales.com/showthread.php?p=177427