### PR TITLE
removed tailing ampersands and question-marks from CMS request url

### DIFF
--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -383,6 +383,8 @@ class toxidCurl
             $sUrl = rtrim($sUrl, '&') . "&{$params}";
         }
 
+        $sUrl = rtrim($sUrl, '&?');
+
         curl_setopt($curl_handle, CURLOPT_URL, $sUrl);
         curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, 1);
         if (!$this->isToxidCurlPage()) {


### PR DESCRIPTION
Optimized the cms-request URL to prevent unexpected behavior. 