### PR TITLE
Prevent TOXID-cURL to end in redirect loop when no url is defined in settings

### DIFF
--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -305,6 +305,9 @@ class toxidCurl
      */
     protected function _getSnippetFromXml($sSnippet)
     {
+        if(str_replace("/","",$this->_getToxidLangSource()) == '')
+           return '';
+		
         $oTypo3Xml      = $this->_getXmlObject();
         $aXpathSnippets = $oTypo3Xml->xpath('//' . $sSnippet . '[1]');
         $sText          = $aXpathSnippets[0];


### PR DESCRIPTION
I wrote a little addition to the _getSnippetFromXml method in toxidcurl.php to prevent the oxid shop from getting into an neverending redirect loop when no url is for the language. Now, in this case, always nothing is returned to prevent this behaviour.