### PR TITLE
CMS snippets are fetched before starting output buffers.

### DIFF
--- a/views/azure/toxid_curl.tpl
+++ b/views/azure/toxid_curl.tpl
@@ -1,16 +1,19 @@
 [{assign var="tpl" value=$oViewConf->getActTplName()}]
 [{assign var='toxid' value=$oViewConf->getToxid()}]
 
+[{assign var="toxidBlockContent" value=$toxid->getCmsSnippet('content')}]
 [{capture append="oxidBlock_content"}]
     <div id="toxid_curl_main">
-        [{$toxid->getCmsSnippet('content')}]
+        [{$toxidBlockContent}]
     </div>
 [{/capture}]
 
+[{assign var="toxidBlockSidebar" value=$toxid->getCmsSnippet('sidebar')}]
 [{capture append="oxidBlock_sidebar"}]
     <div id="toxid_curl_sub">
-        [{$toxid->getCmsSnippet('sidebar')}]
+        [{$toxidBlockSidebar}]
     </div>
 [{/capture}]
 
 [{include file="layout/page.tpl" sidebar="Left"}]
+


### PR DESCRIPTION
If the CMS sends a "404 Not Found" response, the resulting OXID HTML is broken. This behavior is fixed with this commit.