### PR TITLE
Optimized regex pattern

### DIFF
--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -444,6 +444,13 @@ class toxidCurl
             preg_match_all($pattern, $sContent, $matches, PREG_SET_ORDER);
             foreach ($matches as $match) {
 
+                // skip rewrite for defined file extensions
+                if ($this->_getFileExtensionValuesForNoRewrite()) {
+                    if (preg_match('%\.(' . $this->_getFileExtensionValuesForNoRewrite() . ')[\'"]*%i', $match[0])) {
+                        continue;
+                    }
+                }
+
                 if ('src' == $match[1] && $this->getConfig()->getConfigParam('toxidRewriteUrlEncoded') == true) {
                     $sContent = str_replace($match[0], str_replace(urlencode($source), urlencode($target), $match[0]), $sContent);
                     continue;
@@ -452,12 +459,6 @@ class toxidCurl
                 // skip rewrite for defined rel values
                 if ($this->_getRelValuesForNoRewrite()) {
                     if (preg_match('%rel=["\'](' . $this->_getRelValuesForNoRewrite() . ')["\']%', $match[0])) {
-                        continue;
-                    }
-                }
-                // skip rewrite for defined file extensions
-                if ($this->_getFileExtensionValuesForNoRewrite()) {
-                    if (preg_match('%\.(' . $this->_getFileExtensionValuesForNoRewrite() . ')[\'"]*%i', $match[0])) {
                         continue;
                     }
                 }

--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -439,10 +439,16 @@ class toxidCurl
             }
             $target  = rtrim($sShopUrl . $this->_getToxidLangSeoSnippet($iLangId), '/') . '/';
             $source  = $this->_getToxidLangSource($iLangId);
-            $pattern = '%[^<>]*(action|href)=[\'"]' . $source . '[^"\']*?(?:/|\.html|\.php|\.asp)?(?:\?[^"\']*)?[\'"][^<>]*%';
+            $pattern = '%(action|href)=[\'"]?' . $source . '[^\'" >]+%';
 
             preg_match_all($pattern, $sContent, $matches, PREG_SET_ORDER);
             foreach ($matches as $match) {
+
+                if ('src' == $match[1] && $this->getConfig()->getConfigParam('toxidRewriteUrlEncoded') == true) {
+                    $sContent = str_replace($match[0], str_replace(urlencode($source), urlencode($target), $match[0]), $sContent);
+                    continue;
+                }
+
                 // skip rewrite for defined rel values
                 if ($this->_getRelValuesForNoRewrite()) {
                     if (preg_match('%rel=["\'](' . $this->_getRelValuesForNoRewrite() . ')["\']%', $match[0])) {
@@ -460,16 +466,6 @@ class toxidCurl
             }
             unset($match);
 
-            if ($this->getConfig()->getConfigParam('toxidRewriteUrlEncoded') == true) {
-                // rewrite url encoded url in src attribut
-                $patternUrlEncoded = '%[^<>]*src=[\'"][^\'"]+' . preg_quote(urlencode($source), '%') . '[^"\']*?(?:/|\.html|\.php|\.asp)?(?:\?[^"\']*)?[\'"][^<>]*%';
-                preg_match_all($patternUrlEncoded, $sContent, $matches, PREG_SET_ORDER);
-                foreach ($matches as $match) {
-                    $sContent = str_replace($match[0], str_replace(urlencode($source), urlencode($target), $match[0]), $sContent);
-                }
-
-                unset($match);
-            }
         }
 
         return $sContent;

--- a/core/toxidcurl.php
+++ b/core/toxidcurl.php
@@ -439,7 +439,7 @@ class toxidCurl
             }
             $target  = rtrim($sShopUrl . $this->_getToxidLangSeoSnippet($iLangId), '/') . '/';
             $source  = $this->_getToxidLangSource($iLangId);
-            $pattern = '%(action|href)=[\'"]?' . $source . '[^\'" >]+%';
+            $pattern = '%(action|href)=[\'"]' . $source . '[^"\']*?(?:/|\.html|\.php|\.asp)?(?:\?[^"\']*)?[\'"]%';
 
             preg_match_all($pattern, $sContent, $matches, PREG_SET_ORDER);
             foreach ($matches as $match) {


### PR DESCRIPTION
The current pattern for the preg_match_all method can cause a lot of performance issues.

This smaller pattern should serve the same results with less running time. We can remove the file extensions for html, php and asp from the pattern because we already have a feature in toxid to prevent urls with file extensions from being rewritten.

Also, the preg_match_all was run twice. Now it is just running once. This is causing a performance boost, too.